### PR TITLE
Add dynlink support for plugins/linters

### DIFF
--- a/src/analysis/dynlinks/build.ocp
+++ b/src/analysis/dynlinks/build.ocp
@@ -18,11 +18,9 @@
 (*  SOFTWARE.                                                             *)
 (**************************************************************************)
 
-begin library "lint-code"
+begin library "useless_if_dynlink"
   files = [
-    "code_identifier_length.ml"
-    "code_length.ml"
+    "code_useless_if.ml"
   ]
   requires = [ "plugins" ]
-  link = [ "-linkall" ]
 end

--- a/src/analysis/dynlinks/code_useless_if.ml
+++ b/src/analysis/dynlinks/code_useless_if.ml
@@ -25,7 +25,7 @@ module Mascot = Plugin_mascot.PluginMascot
 
 let details = "Detects useless 'if'."
 
-module CodeIdentifierLength = Mascot.MakeLint(struct
+module CodeUseless = Mascot.MakeLint(struct
     let name = "Useless if"
     let short_name = "code-useless-if"
     let details = details
@@ -33,10 +33,10 @@ module CodeIdentifierLength = Mascot.MakeLint(struct
 
 type warnings = UselessIf | ConstantIf
 
-module Warnings = CodeIdentifierLength.MakeWarnings(struct
+module Warnings = CodeUseless.MakeWarnings(struct
     type t = warnings
 
-    let useless loc args = CodeIdentifierLength.new_warning
+    let useless loc args = CodeUseless.new_warning
         loc
         1
         [ Warning.kind_code ]
@@ -44,7 +44,7 @@ module Warnings = CodeIdentifierLength.MakeWarnings(struct
         ~msg:"Useless if-then-else construction."
         ~args
 
-    let constant loc args = CodeIdentifierLength.new_warning
+    let constant loc args = CodeUseless.new_warning
         loc
         2
         [ Warning.kind_code ]
@@ -102,6 +102,6 @@ let iter =
   (module IterArg : ParsetreeIter.IteratorArgument)
 
 (* Registering a main entry to the linter *)
-module MainML = CodeIdentifierLength.MakeInputStructure(struct
+module MainML = CodeUseless.MakeInputStructure(struct
     let main ast = ParsetreeIter.iter_structure iter ast
   end)

--- a/src/core/build.ocp
+++ b/src/core/build.ocp
@@ -25,6 +25,7 @@ begin program "ocp-lint"
     "ocplint.ml"
   ]
   requires = [
+    "dynlink"
     "lint-code"
     "lint-interface"
     "ocplib-system"

--- a/src/core/ocplint.ml
+++ b/src/core/ocplint.ml
@@ -42,8 +42,15 @@ let usage_msg =
     "";
   ]
 
-let core_args_spec = Arg.align [
-    "--project", Arg.String (fun dir -> set_action (ActionLoad dir)),
+let specs : (Arg.key * Arg.spec * Arg.doc) list ref = ref []
+
+let add_spec ((cmd, _, _) as spec) =
+  if List.for_all (fun (key, _, _) -> cmd <> key) !specs then
+    specs := spec :: !specs
+
+let () =
+  specs := Arg.align [
+      "--project", Arg.String (fun dir -> set_action (ActionLoad dir)),
     "DIR   Give a project dir path";
 
     "--list-warnings", Arg.Unit (fun () -> set_action ActionList),
@@ -55,25 +62,20 @@ let core_args_spec = Arg.align [
 
     "--patches", Arg.String (fun files ->
         patches := (Str.split (Str.regexp ",") files)),
-    " List of user defined lint with the patch format."
-  ]
+    " List of user defined lint with the patch format.";
 
-let core_args () =
-  Arg.parse core_args_spec
-    (fun cmd ->
-       Printf.printf "Error: don't know what to do with %s\n%!" cmd;
-       exit 1)
-    usage_msg
+    "--load", Arg.String (fun files ->
+        let l = (Str.split (Str.regexp ",") files) in
+        List.iter Dynlink.loadfile l;
+        List.iter add_spec (Globals.Config.simple_args ())),
+    " Load dynamically plugins with their corresponding 'cmxs' files."
+  ]
 
 let main () =
   (* Getting all options declared in all registered plugins. *)
-  let all_args =
-    Hashtbl.fold (fun plugin _ args ->
-        Globals.Config.simple_args () @ args)
-      Globals.plugins core_args_spec in
-
-  Arg.parse all_args
-    (fun cmd ->
+  List.iter add_spec (Globals.Config.simple_args ());
+  Arg.parse_dynamic specs
+      (fun cmd ->
        Printf.printf "Error: don't know what to do with %s\n%!" cmd;
        exit 1)
     usage_msg;
@@ -88,7 +90,7 @@ let main () =
   | ActionList ->
     exit 0
   | ActionNone ->
-    Arg.usage all_args usage_msg;
+    Arg.usage !specs usage_msg;
     exit 0
 
 let () = main ()

--- a/src/core/ocplint_actions.ml
+++ b/src/core/ocplint_actions.ml
@@ -80,7 +80,7 @@ let is_source file = Filename.check_suffix file "ml"
 let is_interface file = Filename.check_suffix file "mli"
 let is_cmt file = Filename.check_suffix file "cmt"
 let is_cmt file = Filename.check_suffix file "cmt"
-
+let is_cmxs file = Filename.check_suffix file "cmxs"
 
 let register_default_sempatch () =
   (* TODO: Fabrice: vérifier que le fichier existe, sinon prendre celui dans


### PR DESCRIPTION
We can now dynlink a plugin by using the option `--load`:

    ocp-lint --project SRC --load DIR,FILE.cmxs,...
