### PR TITLE
Fix matching of tuples in sempatch

### DIFF
--- a/libs/ocplib-sempatch/lib/ast_pattern_matcher.ml
+++ b/libs/ocplib-sempatch/lib/ast_pattern_matcher.ml
@@ -105,7 +105,7 @@ let apply patch expr =
                   )
               )
           )
-          (Ok ([], env))
+          (Error ([], env))
           expr_list
         >|= (fun (mapped_list, env_list) ->
             Pexp_tuple mapped_list, [ env_list ]


### PR DESCRIPTION
Because of a bug, a tuple was always matched (against any pattern)