### PR TITLE
Guard : add `is_in_range` predicate

### DIFF
--- a/libs/ocplib-sempatch/lib/guard_evaluator.ml
+++ b/libs/ocplib-sempatch/lib/guard_evaluator.ml
@@ -71,6 +71,7 @@ let equiv_ast = apply_to_exprs @@ apply_to_2 @@ fun e1 e2 ->
 
 let (&&&) = apply_to_bool @@ apply_to_2 @@ (fun x y -> x&&y)
 let (|||) = apply_to_bool @@ apply_to_2 @@ (fun x y -> x||y)
+let (guard_not) = apply_to_bool @@ apply_to_1 @@ not
 
 let is_variable = apply_to_exprs @@ apply_to_1 @@ fun e ->
   match e.pexp_desc with
@@ -111,6 +112,7 @@ let functions = [
   "(=)", bool @@ equiv_ast;
   "(&&)", bool @@  (&&&);
   "(||)", bool @@ (|||);
+  "not", bool @@ (guard_not);
   "is_variable", bool @@ is_variable;
   "is_constant", bool @@ is_constant;
   "is_leaf", bool @@ (fun x -> (is_variable x || is_constant x));

--- a/libs/ocplib-sempatch/lib/guard_evaluator.ml
+++ b/libs/ocplib-sempatch/lib/guard_evaluator.ml
@@ -84,6 +84,35 @@ let is_constant = apply_to_exprs @@ apply_to_1 @@ fun e ->
   | Pexp_construct (_, None) -> true
   | _ -> false
 
+let is_int_in_range = fun args ->
+  match args with
+  | [Expr e; Int min; Int max] ->
+    begin
+      let int_expr =
+      match e.pexp_desc with
+      | Pexp_constant (Asttypes.Const_int i) -> Some i
+      | _ -> None
+      in
+      Option.fold (fun _ i -> min <= i && max >= i) false int_expr
+    end
+  | _ -> false
+
+let is_in_range = fun args ->
+  match args with
+  | [Expr e; Int min; Int max] ->
+    begin
+      let int_expr =
+      match e.pexp_desc with
+      | Pexp_constant (Asttypes.Const_int i) -> Some i
+      | Pexp_constant (Asttypes.Const_int32 i) -> Some (Int32.to_int i)
+      | Pexp_constant (Asttypes.Const_int64 i) -> Some (Int64.to_int i)
+      | Pexp_constant (Asttypes.Const_nativeint i) -> Some (Nativeint.to_int i)
+      | _ -> None
+      in
+      Option.fold (fun _ i -> min <= i && max >= i) false int_expr
+    end
+  | _ -> false
+
 let is_integer_lit = apply_to_exprs @@ apply_to_1 @@ fun e ->
   match e.pexp_desc with
   | Pexp_constant (Asttypes.Const_int _)
@@ -119,6 +148,8 @@ let functions = [
   "is_integer_lit", bool @@ is_integer_lit;
   "is_string_lit", bool @@ is_string_lit;
   "is_bool_lit", bool @@ is_bool_lit;
+  "is_int_in_range", bool @@ is_int_in_range;
+  "is_in_range", bool @@ is_in_range;
 ]
 
 let rec eval_ env = function

--- a/libs/ocplib-sempatch/lib/guard_evaluator.ml
+++ b/libs/ocplib-sempatch/lib/guard_evaluator.ml
@@ -5,6 +5,7 @@ open Guard
 type t =
   | Expr of Parsetree.expression
   | Bool of bool
+  | Int of int
 
 type fn = string * (t list -> t) (* name, fun *)
 
@@ -29,14 +30,14 @@ let find_var var_name env =
 let apply_to_bool f args =
   let unwrap_bool = function
     | Bool b -> b
-    | Expr _ -> raise TypeError
+    | _ -> raise TypeError
   in
   f (List.map unwrap_bool args)
 
 let apply_to_exprs f args =
   let unwrap_expr = function
-    | Bool _ -> raise TypeError
     | Expr e -> e
+    | _ -> raise TypeError
   in
   f (List.map unwrap_expr args)
 
@@ -125,11 +126,12 @@ let rec eval_ env = function
       try List.assoc f functions with Not_found -> raise (Undefined_function f)
     in
     fn (List.map (eval_ env) args)
+  | Litt_integer i -> Int i
 
 let eval env guard =
   match eval_ env guard with
   | Bool b -> b
-  | Expr _ -> raise TypeError
+  | _ -> raise TypeError
 
 let eval_union env guards =
   List.fold_left (fun accu guard -> accu && eval env guard) true guards

--- a/libs/ocplib-sempatch/lib/parsing/guard.ml
+++ b/libs/ocplib-sempatch/lib/parsing/guard.ml
@@ -1,3 +1,4 @@
 type t =
   | Variable of string
+  | Litt_integer of int
   | Apply of string * t list

--- a/libs/ocplib-sempatch/lib/parsing/guard_lexer.mll
+++ b/libs/ocplib-sempatch/lib/parsing/guard_lexer.mll
@@ -4,6 +4,7 @@
 }
 
 let id = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*
+let number = '-'? [ '0' - '9' ]*
 let infix_symbol = [ '=' '|' '&' ]*
 let open_paren = '('
 let close_paren = ')'
@@ -14,6 +15,7 @@ rule read =
   parse
   | space { read lexbuf }
   | id { ID (Lexing.lexeme lexbuf) }
+  | number { NUMBER (int_of_string (Lexing.lexeme lexbuf)) }
   | infix_symbol { INFIX_OP (Lexing.lexeme lexbuf) }
   | open_paren { OPENING_PAREN }
   | close_paren { CLOSING_PAREN }

--- a/libs/ocplib-sempatch/lib/parsing/guard_parser.mly
+++ b/libs/ocplib-sempatch/lib/parsing/guard_parser.mly
@@ -1,5 +1,6 @@
 %token<string> ID
 %token<string> INFIX_OP
+%token<int> NUMBER
 %token OPENING_PAREN
 %token CLOSING_PAREN
 %token COMMA
@@ -19,3 +20,4 @@ expr:
   { Guard.Apply (fn, args) }
   | OPENING_PAREN e = expr CLOSING_PAREN { e }
   | var = ID { Guard.Variable var }
+  | number = NUMBER { Guard.Litt_integer number }

--- a/src/analysis/plugins/sempatch.md
+++ b/src/analysis/plugins/sempatch.md
@@ -15,6 +15,14 @@ when: "e1 = e2"
 + decr e1
 ```
 
+@AddSmallInteger
+expressions: e1, e2
+when : "is_in_range(e2, -1, 1) && not(is_int_in_range(e2, -1, 1))"
+message : "use `succ`, `pred` or nothing instead of adding $e2"
+```
+add e1 e2
+```
+
 @CompToFalse
 expressions: cond
 message: "Use 'not $cond' instead of '$cond = false'."
@@ -64,10 +72,11 @@ message: "Use 'not $cond' instead of '$cond <> true'."
 ```
 
 @ EmptyListComparison
-expressions: l, e1, e2
-message: "Use a pattern matching instead of comparing to `0`."
+expressions: l, i
+message: "Use a pattern matching instead of comparing to `$i`."
+when : "is_int_in_range(i, 0, 5)"
 ```
-List.length l = 0
+List.length l = i
 ```
 
 @ ConstantIf

--- a/testsuite/sempatch_empty_list_compare/ocp-lint.result
+++ b/testsuite/sempatch_empty_list_compare/ocp-lint.result
@@ -1,4 +1,14 @@
 File "testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml", line 1:
   Missing interface for 'testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml'.
-File "testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml", line 3, characters 5-25:
+File "testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml", line 4, characters 5-25:
   Use a pattern matching instead of comparing to `0`.
+File "testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml", line 6, characters 5-25:
+  Use a pattern matching instead of comparing to `1`.
+File "testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml", line 8, characters 5-25:
+  Use a pattern matching instead of comparing to `2`.
+File "testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml", line 10, characters 5-25:
+  Use a pattern matching instead of comparing to `3`.
+File "testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml", line 12, characters 5-25:
+  Use a pattern matching instead of comparing to `4`.
+File "testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml", line 14, characters 5-25:
+  Use a pattern matching instead of comparing to `5`.

--- a/testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml
+++ b/testsuite/sempatch_empty_list_compare/test_sempatch_empty_list_cmp.ml
@@ -1,4 +1,18 @@
 
 let test_empty_list_cmp list texpr fexpr =
+  (* Matched by @EmptyListComparison *)
   if List.length list = 0 then texpr
-  else fexpr
+  else fexpr;
+  if List.length list = 1 then texpr
+  else fexpr;
+  if List.length list = 2 then texpr
+  else fexpr;
+  if List.length list = 3 then texpr
+  else fexpr;
+  if List.length list = 4 then texpr
+  else fexpr;
+  if List.length list = 5 then texpr
+  else fexpr;
+  (* Not matched *)
+  if List.length list = 6 then texpr
+  else fexpr;

--- a/testsuite/sempatch_succ_pred/ocp-lint.result
+++ b/testsuite/sempatch_succ_pred/ocp-lint.result
@@ -1,0 +1,8 @@
+File "testsuite/sempatch_succ_pred/test_sempatch_succ_pred.ml", line 1:
+  Missing interface for 'testsuite/sempatch_succ_pred/test_sempatch_succ_pred.ml'.
+File "testsuite/sempatch_succ_pred/test_sempatch_succ_pred.ml", line 2, characters 22-31:
+  use `succ`, `pred` or nothing instead of adding 1L
+File "testsuite/sempatch_succ_pred/test_sempatch_succ_pred.ml", line 1, characters 22-31:
+  use `succ`, `pred` or nothing instead of adding 1l
+File "testsuite/sempatch_succ_pred/test_sempatch_succ_pred.ml", line 3, characters 26-35:
+  use `succ`, `pred` or nothing instead of adding 1n

--- a/testsuite/sempatch_succ_pred/test_sempatch_succ_pred.ml
+++ b/testsuite/sempatch_succ_pred/test_sempatch_succ_pred.ml
@@ -1,0 +1,4 @@
+let _ = ignore Int32.(add 1l 1l)
+let _ = ignore Int64.(add 1L 1L)
+let _ = ignore Nativeint.(add 1n 1n)
+let _ = let add = (+) in ignore (add 1 1)


### PR DESCRIPTION
`is_in_range(e, min, max)` checks whether `e` is an integer (`int`, `int32`, `int64` or `nativeint`) constant between `min` and `max` (included).
`is_int_in_range` does the same but only for the type `int`