### PR TITLE
Fix multiple reporting of errors in sempatch

### DIFF
--- a/libs/ocplib-sempatch/lib/ast_pattern_matcher.ml
+++ b/libs/ocplib-sempatch/lib/ast_pattern_matcher.ml
@@ -32,7 +32,7 @@ let apply_replacements tree attributes var_replacements =
   in
   mapper.Ast_mapper.expr mapper new_tree
 
-let apply patch expr =
+let apply recurse patch expr =
   let is_meta_expr e = List.mem e (patch.header.meta_expr)
   and apply_to_list mapper env patch elements =
     List.fold_left (fun mapped elt ->
@@ -487,8 +487,13 @@ let apply patch expr =
   in
   let expr = Parsed_patches.preprocess_src_expr expr
   and patch = Parsed_patches.preprocess patch
+  and apply_fun =
+  if recurse then
+    apply_to_expr
+  else
+    match_at_root.Ast_maybe_mapper2.expr match_at_root
   in
-  apply_to_expr Environment.empty ~expr ~patch:(patch.body)
+  apply_fun Environment.empty ~expr ~patch:(patch.body)
   |> Res.map (fun (tree, env) ->
       Parsed_patches.postprocess tree, env.Environment.matches
     )

--- a/libs/ocplib-sempatch/lib/sempatch.mli
+++ b/libs/ocplib-sempatch/lib/sempatch.mli
@@ -52,6 +52,9 @@ sig
       and returns the couple [patched_tree, matches] *)
   val apply : t -> Ast_element.t -> Ast_element.t * Match.t list
 
+  (** Same as [apply] except that it tries to match patches only at the root of the AST *)
+  val apply_nonrec : t -> Ast_element.t -> Ast_element.t * Match.t list
+
   (** [sequential_apply patches tree] applies applies all the patches in order
       to tree ({i ie} the first patch [p1] is applied to [tree], the second one
       to the result [tree'] of the application of [p1] to [tree], and so on.
@@ -64,6 +67,9 @@ sig
       returns the concatenation of all the matches
   *)
   val parallel_apply : t list -> Ast_element.t -> Match.t list
+
+  (** Same as [parallel_apply] except that it tries to match patches only at the root of the AST *)
+  val parallel_apply_nonrec : t list -> Ast_element.t -> Match.t list
 end
 
 module Failure:

--- a/src/kernel/services/plugins/plugin_API.ml
+++ b/src/kernel/services/plugins/plugin_API.ml
@@ -110,7 +110,7 @@ module MakePlugin(P : Plugin_types.PluginArg) = struct
         let enter_expression expr =
           List.iter (fun patches ->
               let matches =
-                Patch.parallel_apply patches (Ast_element.Expression expr) in
+                Patch.parallel_apply_nonrec patches (Ast_element.Expression expr) in
               List.iter (fun matching ->
                   let patch =
                     List.find


### PR DESCRIPTION
This patch adds the possibility for sempatch to try to apply a patch only at the root of the expression (instead of anything in the tree), and uses it in the plugin.
This prevent errors to be reported each time the patch is applied to a different AST node by the parsetree iterator.

cc @OCamlPro-Bozman @Michaaell