### PR TITLE
Remove misleading line in help message

### DIFF
--- a/src/core/ocplint.ml
+++ b/src/core/ocplint.ml
@@ -39,7 +39,6 @@ let usage_msg =
   String.concat "\n" [
     "Usage:";
     Printf.sprintf "   %s [OPTIONS] --project DIR" name;
-    Printf.sprintf "   %s [OPTIONS] --project DIR --patches foo.md,bar.md" name;
     "";
   ]
 


### PR DESCRIPTION
The help message (`ocp-lint.asm --help`) indicates under "usage" :
```
ocp-lint.asm [OPTIONS] --project DIR --patches foo.md,bar.m
```

The "--sempatch" option doesn't exist anymore (it has been replaced by "--load-patches", and putting options on this line seems irrelevant, as they are described below (or if it is done, every option should be included, and it should be manually updated if options change which is error prone).