### PR TITLE
Update command line options

### DIFF
--- a/scripts/pre-commit-lint
+++ b/scripts/pre-commit-lint
@@ -2,7 +2,7 @@
 
 LINT=_obuild/ocp-lint/ocp-lint.asm
 
-$LINT --warn-error --project src > /dev/null
+$LINT --warn-error --path src > /dev/null
 
 if [ "$?" = 0 ]; then
     exit 0

--- a/src/core/ocplint.ml
+++ b/src/core/ocplint.ml
@@ -74,9 +74,8 @@ let () =
         List.iter add_spec (Globals.Config.simple_args ())),
     " Load dynamically plugins with their corresponding 'cmxs' files.";
 
-    "--save-config", Arg.Unit (fun () ->
-        set_action (ActionSave)),
-    " List of user defined lint with the patch format.";
+    "--init", Arg.Unit (fun () -> set_action (ActionSave)),
+    " Initialize ocp-lint with a default config file.";
   ]
 
 let start_lint dir =
@@ -105,6 +104,7 @@ let main () =
   | ActionList ->
     exit 0
   | ActionSave ->
+    (* TODO: pour mika: création des répertoires de sauvegarde de DB *)
     Globals.Config.save ();
     exit 0
   | ActionNone ->

--- a/testsuite/testsuite.ml
+++ b/testsuite/testsuite.ml
@@ -69,7 +69,7 @@ let starts_with str ~substring =
 
 let run_ocp_lint ocplint dir =
   let output = dir // output in
-  let project_arg = "--project" in
+  let project_arg = "--path" in
   let output_arg = "--output-txt" in
   let sempatch_args =
     if Sys.file_exists (dir // sempatch_file)


### PR DESCRIPTION
- We can now use `ocp-lint` without arguments. It will start the lint
process on the "." path.
- The option `--project` is renamed in `--path`.
- Update testsuite.ml with the new option