### PR TITLE
Some fixes and new features

### DIFF
--- a/plugins/ocp-lint-plugin-sempatch/user_patch.ml
+++ b/plugins/ocp-lint-plugin-sempatch/user_patch.ml
@@ -24,7 +24,7 @@ module UserDefined = Plugin_patch.PluginPatch.MakeLintPatch(struct
     let details = "Lint from semantic patches (user defined)."
     let patches =
       try
-        let path = Sys.getenv "PATCHES" in
+        let path = Sys.getenv "OCPLINT_PATCHES" in
         let files = ref [] in
         Lint_utils.iter_files (fun file ->
             if Filename.check_suffix file ".md" then

--- a/tools/ocp-lint/api/build.ocp
+++ b/tools/ocp-lint/api/build.ocp
@@ -22,6 +22,7 @@ begin library "ocp-lint-api-types"
   files = [
     "lint_map.ml"
     "lint_input.ml"
+    "lint_warning_decl.ml"
     "lint_types.ml"
     "lint_plugin_error.ml"
     "lint_warning_types.ml"

--- a/tools/ocp-lint/api/lint_plugin_api.mli
+++ b/tools/ocp-lint/api/lint_plugin_api.mli
@@ -37,7 +37,7 @@ sig
       on semantic patches (see ocplib-sempatch). It takes the files names of
       the patches as arguments and automatically register the linter
       into a plugin. *)
-  module MakeLintPatch : functor (CA : Lint_types.LINTPATCHARG) ->  sig  end
+  module MakeLintPatch : functor (CA : Lint_types.LINTPATCHARG) ->  sig end
 
   (** [MakeLint] is a functor which takes a module of type [Lint.LintArg] as
       argument. It allows to create a linter and automatically register it to

--- a/tools/ocp-lint/api/lint_types.ml
+++ b/tools/ocp-lint/api/lint_types.ml
@@ -34,5 +34,10 @@ module type LINTPATCHARG = sig
 end
 
 module type LINT = sig
+  val name : string
+  val short_name : string
+  val details : string
+  val enable : bool
   val inputs : Lint_input.input list
+  val wdecls : Lint_warning_decl.WarningDeclaration.t
 end

--- a/tools/ocp-lint/api/lint_types.mli
+++ b/tools/ocp-lint/api/lint_types.mli
@@ -38,5 +38,10 @@ module type LINTPATCHARG = sig
 end
 
 module type LINT = sig
+  val name : string
+  val short_name : string
+  val details : string
+  val enable : bool
   val inputs : Lint_input.input list
+  val wdecls : Lint_warning_decl.WarningDeclaration.t
 end

--- a/tools/ocp-lint/api/lint_warning.mli
+++ b/tools/ocp-lint/api/lint_warning.mli
@@ -31,18 +31,6 @@ val new_kind : string -> Lint_warning_types.kind
 val kind_to_string : Lint_warning_types.kind -> string
 
 (**** Warnings data structure. ****)
-
-module WarningDeclaration : sig
-  (** Abstract type representation the warning declaration data structure. *)
-  type t
-
-  (** The empty set of warning declaration. *)
-  val empty : unit -> t
-
-  (** [add wdecl wdecl_set] adds the warning declaration [wdecl] to [wset]. *)
-  val add : Lint_warning_types.warning_declaration -> t -> unit
-end
-
 module Warning : sig
 
   (** [add loc id kinds short_name message wset] adds the warning to [wset] with

--- a/tools/ocp-lint/api/lint_warning_decl.ml
+++ b/tools/ocp-lint/api/lint_warning_decl.ml
@@ -18,29 +18,20 @@
 (*  SOFTWARE.                                                             *)
 (**************************************************************************)
 
-open Lint_warning_types
+module WarningDeclaration = struct
+  (* Warning declaration Set *)
+  module WDeclSet = Set.Make (struct
+      type t = Lint_warning_types.warning_declaration
+      let compare = Pervasives.compare
+    end)
 
-let kind_code = Code
-let kind_typo = Typo
-let kind_interface = Interface
-let kind_metrics = Metrics
+  type t = WDeclSet.t ref
 
-let new_kind kind = Custom kind
+  let empty () = ref WDeclSet.empty
 
-let kind_to_string = function
-  | Code -> "code"
-  | Typo -> "typographie"
-  | Interface -> "interface"
-  | Metrics -> "metrics"
-  | Custom kind -> kind
+  let add decl decls = decls := WDeclSet.add decl !decls
 
-module Warning = struct
+  let union decls1 decls2 = ref (WDeclSet.union !decls1 !decls2)
 
-  let add_warning pname lname warning =
-    Lint_db.DefaultDB.update pname lname warning
-
-  let add pname lname loc id decl output =
-    let instance = {id; decl} in
-    let warning = {loc; instance; output} in
-    add_warning pname lname warning
+  let iter f decls = WDeclSet.iter f !decls
 end

--- a/tools/ocp-lint/api/lint_warning_decl.mli
+++ b/tools/ocp-lint/api/lint_warning_decl.mli
@@ -18,29 +18,18 @@
 (*  SOFTWARE.                                                             *)
 (**************************************************************************)
 
-open Lint_warning_types
+module WarningDeclaration : sig
+  (** Abstract type representation the warning declaration data structure. *)
+  type t
 
-let kind_code = Code
-let kind_typo = Typo
-let kind_interface = Interface
-let kind_metrics = Metrics
+  (** The empty set of warning declaration. *)
+  val empty : unit -> t
 
-let new_kind kind = Custom kind
+  (** [add wdecl wdecl_set] adds the warning declaration [wdecl] to [wset]. *)
+  val add : Lint_warning_types.warning_declaration -> t -> unit
 
-let kind_to_string = function
-  | Code -> "code"
-  | Typo -> "typographie"
-  | Interface -> "interface"
-  | Metrics -> "metrics"
-  | Custom kind -> kind
+  (** [union wdecl1 wdecl2] union between [wdecl1] and [wdecl2]. *)
+  val union : t -> t -> t
 
-module Warning = struct
-
-  let add_warning pname lname warning =
-    Lint_db.DefaultDB.update pname lname warning
-
-  let add pname lname loc id decl output =
-    let instance = {id; decl} in
-    let warning = {loc; instance; output} in
-    add_warning pname lname warning
+  val iter : (Lint_warning_types.warning_declaration -> unit) -> t -> unit
 end

--- a/tools/ocp-lint/main/build.ocp
+++ b/tools/ocp-lint/main/build.ocp
@@ -27,6 +27,8 @@ begin library "ocp-lint-lib"
   requires = [
     "dynlink"
     "ocp-lint-output"
+    "ocp-lint-api-types"
+    "ocp-lint-api"
   ]
 end
 

--- a/tools/ocp-lint/main/lint.ml
+++ b/tools/ocp-lint/main/lint.ml
@@ -66,6 +66,9 @@ let () =
     "--output-txt", Arg.String (fun file -> output_text := Some file),
     "FILE   Output results in a text file.";
 
+    "--list", Arg.Unit (fun () -> set_action ActionList),
+    " List of every plugins and warnings.";
+
     "--warn-error", Arg.Unit (fun () ->
         exit_status := 1),
     " Every warning returns an error status code.";
@@ -110,6 +113,7 @@ let main () =
     start_lint dir;
     exit 0 (* No warning, we can exit successfully *)
   | ActionList ->
+    Lint_actions.list_plugins Format.std_formatter;
     exit 0
   | ActionInit ->
     Lint_globals.Config.save ();

--- a/tools/ocp-lint/main/lint.ml
+++ b/tools/ocp-lint/main/lint.ml
@@ -112,6 +112,7 @@ let main () =
   | ActionList ->
     exit 0
   | ActionInit ->
+    Lint_globals.Config.save ();
     Lint_actions.init_olint_dir ()
   | ActionSave ->
     Lint_globals.Config.save ();

--- a/tools/ocp-lint/main/lint_actions.mli
+++ b/tools/ocp-lint/main/lint_actions.mli
@@ -30,6 +30,8 @@ val scan :
   string ->
   unit
 
+val list_plugins : Format.formatter -> unit
+
 (** [init_db ()] create dir to dump the db. *)
 val init_olint_dir : unit -> unit
 


### PR DESCRIPTION
 - Rename `PATCHES` environment variable to `OCPLINT_PATCHES`
 - Save configuration when using `--init` option
 - Add option `--list` to print available plugins and linters with their corresponding default activation status 