### PR TITLE
gitignore all _olint dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ _obuild
 *.err
 *.out
 *.output
-/_olint
+_olint


### PR DESCRIPTION
They are especially annoying as they are created during the tests and pollute `git status`