### PR TITLE
Add clean db feature

### DIFF
--- a/tools/ocp-lint/db/lint_db_types.ml
+++ b/tools/ocp-lint/db/lint_db_types.ml
@@ -44,8 +44,8 @@ type t = (string, file_map) Hashtbl.t
 type errors = (string, error_set) Hashtbl.t
 
 module type DATABASE_IO = sig
-  val load : string -> int * string * plugin_map * error_set
-  val save : string -> int * string * plugin_map * error_set -> unit
+  val load : string -> int * float * string * plugin_map * error_set
+  val save : string -> int * float * string * plugin_map * error_set -> unit
 end
 
 module type DATABASE = sig
@@ -62,7 +62,7 @@ module type DATABASE = sig
   val remove_entry : string -> unit
   val add_entry : string -> string -> string -> unit
   val add_error : string -> error -> unit
-  val clean : string list -> unit
+  val clean : int -> unit
   val update : string -> string -> Lint_warning_types.warning -> unit
   val already_run : string -> string -> string -> bool
   val has_warning : unit -> bool

--- a/tools/ocp-lint/db/lint_db_types.mli
+++ b/tools/ocp-lint/db/lint_db_types.mli
@@ -43,8 +43,8 @@ type errors = (string, error_set) Hashtbl.t
 
 
 module type DATABASE_IO = sig
-  val load : string -> int * string * plugin_map * error_set
-  val save : string -> int * string * plugin_map * error_set -> unit
+  val load : string -> int * float * string * plugin_map * error_set
+  val save : string -> int * float * string * plugin_map * error_set -> unit
 end
 
 module type DATABASE = sig
@@ -61,7 +61,7 @@ module type DATABASE = sig
   val remove_entry : string -> unit
   val add_entry : string -> string -> string -> unit
   val add_error : string -> error -> unit
-  val clean : string list -> unit
+  val clean : int -> unit
   val update : string -> string -> Lint_warning_types.warning -> unit
   val already_run : string -> string -> string -> bool
   val has_warning : unit -> bool

--- a/tools/ocp-lint/main/lint_actions.ml
+++ b/tools/ocp-lint/main/lint_actions.ml
@@ -29,6 +29,14 @@ let ignored = Lint_globals.Config.create_option
     (SimpleConfig.list_option SimpleConfig.string_option)
     []
 
+let db_persistence = Lint_globals.Config.create_option
+    ["db_persistence"]
+    "Time before erasing cached results (in days)."
+    "Time before erasing cached results (in days)."
+    0
+    (SimpleConfig.int_option)
+    1
+
 let scan_project path = (* todo *)
   Format.printf "Scanning files in project %S...\n%!" path;
   let found_files =
@@ -309,6 +317,7 @@ let lint_sequential no_db db_dir severity path =
   (* We filter the global ignored modules/files.  *)
   (* let no_db = init_db no_db path in *)
   let (db_dir, no_db) = init_db no_db db_dir path in
+  Lint_db.DefaultDB.clean !!db_persistence;
   let sources = filter_modules (scan_project path) !!ignored in
   List.iter (run db_dir) sources;
   Lint_db.DefaultDB.merge sources;


### PR DESCRIPTION
This will run a clean function everytime ocp-lint is call. The cache file with an older version or older than a certain time will be removed