### PR TITLE
Store arbitrary fields in the header

### DIFF
--- a/libs/ocplib-sempatch/lib/parsing/parsed_patches.ml
+++ b/libs/ocplib-sempatch/lib/parsing/parsed_patches.ml
@@ -1,12 +1,13 @@
 open Parsetree
+open Std_utils
 
 module Type =
 struct
   type header = {
     meta_expr : string list;
-    message : string option;
     name : string;
     guard : Guard.t list;
+    keyvals : string StringMap.t;
   }
 
   type body = Automaton.A.state
@@ -31,13 +32,13 @@ type unprocessed_patch = {
 let void_header = {
   guard = [];
   meta_expr = [];
-  message = None;
+  keyvals = StringMap.empty;
   name = "";
 }
 
 type setting =
   | Expressions of string list
-  | Message of string
+  | KeyVal of string * string
   | Name of string
   | Guard of Guard.t
 
@@ -46,7 +47,7 @@ let raisePatchError e = raise Failure.(SempatchException (Patch e))
 let add_header_field header = function
   | Guard g -> { header with guard = g :: header.guard }
   | Expressions v -> { header with meta_expr = v @ header.meta_expr }
-  | Message m -> { header with message = Some m }
+  | KeyVal (k, v) -> { header with keyvals = StringMap.add k v header.keyvals }
   | Name m -> { header with name = m }
 
 let header_from_list l = List.fold_left add_header_field void_header l

--- a/libs/ocplib-sempatch/lib/parsing/patch_lexer.mll
+++ b/libs/ocplib-sempatch/lib/parsing/patch_lexer.mll
@@ -7,6 +7,7 @@
 let white = [' ' '\t']+
 let newline = ('\r' | '\n' | "\r\n")
 let id = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*
+let number = [ '0'-'9' ]+
 let title_delim = '@'
 let code_delim = "```"
 
@@ -33,6 +34,7 @@ rule read =
   | ',' { COMMA }
   | title_delim { TITLE_DELIM }
   | id { ID (Lexing.lexeme lexbuf) }
+  | number { NUMBER (int_of_string @@ Lexing.lexeme lexbuf) }
   | comment_begin { read_comment lexbuf; read lexbuf }
   | eof { EOF }
   | _ { raise (Failure.SempatchException

--- a/libs/ocplib-sempatch/lib/parsing/patch_lexer.mll
+++ b/libs/ocplib-sempatch/lib/parsing/patch_lexer.mll
@@ -23,7 +23,6 @@ rule read =
     CODE (Buffer.to_bytes str_litteral_buf |> Bytes.to_string)
   }
   | "expressions" { EXPR_KW }
-  | "message" { MESSAGES_KW }
   | "name" { NAME_KW }
   | "when" { GUARD_KW }
   | "\"" {

--- a/libs/ocplib-sempatch/lib/parsing/patch_parser.mly
+++ b/libs/ocplib-sempatch/lib/parsing/patch_parser.mly
@@ -12,6 +12,7 @@
 %token NAME_KW
 %token GUARD_KW
 %token<string> STRING
+%token<int> NUMBER
 
 %start <(string * Parsed_patches.unprocessed_patch) list> sempatch
 %%
@@ -52,3 +53,4 @@ eols_option:
 string_or_id:
   | s = STRING { s }
   | s = ID { s }
+  | n = NUMBER { string_of_int n }

--- a/libs/ocplib-sempatch/lib/parsing/patch_parser.mly
+++ b/libs/ocplib-sempatch/lib/parsing/patch_parser.mly
@@ -9,7 +9,6 @@
 %token TITLE_DELIM
 
 %token EXPR_KW
-%token MESSAGES_KW
 %token NAME_KW
 %token GUARD_KW
 %token<string> STRING
@@ -31,12 +30,12 @@ patch_header:
 header_def:
   | EXPR_KW COLON exprs = separated_nonempty_list(COMMA, ID) eols
   { Parsed_patches.Expressions exprs }
-  | MESSAGES_KW COLON msg = string_or_id eols { Parsed_patches.Message msg }
   | NAME_KW COLON msg = string_or_id eols { Parsed_patches.Name msg }
   | GUARD_KW COLON guard = string_or_id eols
   { Parsed_patches.Guard
   (Guard_parser.guard Guard_lexer.read (Lexing.from_string guard))
   }
+  | key = ID COLON value = string_or_id eols { Parsed_patches.KeyVal (key, value) }
 
 patch_body:
   | cde = CODE eols

--- a/libs/ocplib-sempatch/lib/sempatch.ml
+++ b/libs/ocplib-sempatch/lib/sempatch.ml
@@ -16,8 +16,9 @@ struct
     |> List.map Parsed_patches.preprocess
 
   let get_name p = p.header.name
-  let get_msg p = p.header.message
   let get_metavariables p = p.header.meta_expr
+  let get_field field p = StringMap.get field p.header.keyvals
+  let get_msg = get_field "message"
 
   let apply patch ast = let open Ast_element in
     match ast with

--- a/libs/ocplib-sempatch/lib/sempatch.mli
+++ b/libs/ocplib-sempatch/lib/sempatch.mli
@@ -45,7 +45,7 @@ sig
   val get_name : t -> string
   val get_msg : t -> string option
   val get_metavariables : t -> string list
-  (* val get_field : t -> string -> string *) (* When implemented *)
+  val get_field : string -> t -> string option
 
   (** {2 Application of patches} *)
 

--- a/libs/ocplib-sempatch/lib/std_utils.ml
+++ b/libs/ocplib-sempatch/lib/std_utils.ml
@@ -256,6 +256,7 @@ module StringMap:
 sig
   include Map.S with type key = string
   val from_list_pair : (string * 'a) list -> 'a t
+  val get : string -> 'a t -> 'a option
 end
 =
 struct
@@ -267,6 +268,11 @@ struct
       (fun map (k, e) -> M.add k e map)
       M.empty
       l
+
+  let get k sm =
+    try
+      Some (M.find k sm)
+    with Not_found -> None
 end
 
 module Messages :


### PR DESCRIPTION
This patch allows to use arbitrary headers fields, like the standard headers, defined with a line of the form `name: value` (where name is an ident in the form `[a-z A-z][:alphanum:]*`). Value can be an ident (in the same form as name), or a quote delimited string, or a litteral number.

For example, the following are valid declarations:

```
foo: bar
blah: "This is a string:
size: 1245
```

whereas those aren't:

```
1stItem: blah
this: some thing
```

The value of a field can be accessed by `Patch.get_field : string -> Patch.t -> string option`