### PR TITLE
Improve cmt management

### DIFF
--- a/tools/ocp-lint/utils/build.ocp
+++ b/tools/ocp-lint/utils/build.ocp
@@ -26,5 +26,6 @@ begin library "ocp-lint-utils"
   requires = [
     "str"
     "ocplib-system"
+    "compiler-libs.common"
   ]
 end

--- a/tools/ocp-lint/utils/lint_utils.mli
+++ b/tools/ocp-lint/utils/lint_utils.mli
@@ -22,6 +22,7 @@ type file_struct = {
   name : string;
   norm : string;
   hash : string;
+  cmt : string option;
   ignored : string list;
 }
 
@@ -64,7 +65,18 @@ val mk_temp_dir : string -> string
 
 val db_hash : string -> string
 
-val mk_file_struct : string -> string -> string list -> file_struct
+(** [split_sources sources] will match the .cmt files to their .ml files.
+    This return 2 lists : - the association list (file.ml, file.cmt)
+                          - the sources without the .cmt *)
+val split_sources :
+  string list -> ((string * string * string) list * string list)
+
+val mk_file_struct :
+  string ->
+  string ->
+  string list ->
+  (string * string * string) list ->
+  file_struct
 
 val save_file_struct : string -> file_struct -> string
 


### PR DESCRIPTION
Ocp-lint will try to match .cmt to a .ml file.
The orphan .cmt won't be used to run analyses.
The warning raised by an analyse on the typedtree will have their
loc updated to match the .ml file that matched the .cmt.